### PR TITLE
Give each npm run buffer a unique name based on the command run

### DIFF
--- a/npm.el
+++ b/npm.el
@@ -263,13 +263,14 @@ SCRIPT can be passed in or selected from a list of scripts configured in a packa
   (save-some-buffers (not compilation-ask-about-save)
                      (when (boundp 'compilation-save-buffers-predicate)
                        compilation-save-buffers-predicate))
-  (let ((scripts (npm-parse-scripts (process-lines "npm" "run"))) (buffer-name "*npm run*"))
+  (let* ((scripts (npm-parse-scripts (process-lines "npm" "run")))
+         (selected-script (or script (ido-completing-read "Select script to run: " scripts)))
+         (script (concat "npm run " selected-script))
+         (buffer-name (concat "*npm run: " selected-script "*")))
     (when (get-buffer buffer-name)
       (kill-buffer buffer-name))
-    (let ((script (concat "npm run "
-                          (or script (ido-completing-read "Select script to run: " scripts)))))
       (with-current-buffer (get-buffer-create buffer-name)
-        (npm-exec-with-path 'compilation-start script 'npm-compilation-mode (lambda (m) (buffer-name)))))))
+        (npm-exec-with-path 'compilation-start script 'npm-compilation-mode (lambda (m) (buffer-name))))))
 
 
 (provide 'npm)


### PR DESCRIPTION
I've had this sitting locally for a while without merging it back.

It gives each run buffer a unique name based on the name of the run script. So if I do `M-x npm-run` and select "server" it will create a buffer named `*npm run: server*`

This makes it easy to have multiple run buffers for different commands going at once.
